### PR TITLE
add the new option remote.WithJobs to default the operator according to CPU quota

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -362,7 +362,6 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -1174,7 +1173,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -3,9 +3,6 @@ package builder
 import (
 	"archive/tar"
 	"fmt"
-	"github.com/google/go-containerregistry/pkg/logs"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"io"
 	"io/fs"
 	"io/ioutil"
@@ -14,6 +11,10 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
@@ -52,6 +53,7 @@ func Build(options Options, dirs ...string) (string, error) {
 	}
 
 	StepLogger.Printf("Pushing image %s (insecure=%v)...", options.Target, options.PushInsecure)
+
 	if err := Push(newImage, options); err != nil {
 		return "", err
 	}

--- a/pkg/builder/image.go
+++ b/pkg/builder/image.go
@@ -20,7 +20,7 @@ func Pull(options Options) (v1.Image, error) {
 		return nil, fmt.Errorf("parsing tag %q: %v", options.Base, err)
 	}
 
-	remoteOptions := makeRemoteOptions(options.PullConfigDir)
+	remoteOptions := makeRemoteOptions(options, options.PullConfigDir)
 	return remote.Image(ref, remoteOptions...)
 }
 
@@ -31,7 +31,7 @@ func Push(img v1.Image, options Options) error {
 		return fmt.Errorf("parsing tag %q: %v", options.Target, err)
 	}
 
-	remoteOptions := makeRemoteOptions(options.PushConfigDir)
+	remoteOptions := makeRemoteOptions(options, options.PushConfigDir)
 	return remote.Write(tag, img, remoteOptions...)
 }
 
@@ -42,7 +42,10 @@ func makeNameOptions(insecure bool) (nameOptions []name.Option) {
 	return
 }
 
-func makeRemoteOptions(configDir string) (remoteOptions []remote.Option) {
+func makeRemoteOptions(options Options, configDir string) (remoteOptions []remote.Option) {
+	if options.jobs > 0 {
+		remoteOptions = append(remoteOptions, remote.WithJobs(options.jobs))
+	}
 	if configDir != "" {
 		keyChain := NewDirKeyChain(configDir)
 		remoteOptions = append(remoteOptions, remote.WithAuthFromKeychain(keyChain))

--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -13,4 +13,5 @@ type Options struct {
 	Stdout        io.Writer
 	Stderr        io.Writer
 	Recursive     bool
+	jobs          int
 }


### PR DESCRIPTION
Following [#3340](https://github.com/apache/camel-k/issues/3340) in Camel-K, introduction of the new option [remote.WithJobs()  ](https://github.com/google/go-containerregistry/pull/803) is required to improve the concurrency of the underlying Container Image push implementation by making the operator aware of the CPU quota set on the operator container. 

cc @astefanutti 