### PR TITLE
feat: clear entrypoint option

### DIFF
--- a/e2e/core_test.go
+++ b/e2e/core_test.go
@@ -1,8 +1,9 @@
 package e2e
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	. "github.com/onsi/gomega"
 )
@@ -89,4 +90,18 @@ func TestRecursive(t *testing.T) {
 		"./files/04-recursive:/app")).To(BeNil())
 
 	assertDataMatch(t, target, isRegistryInsecure(), "/app", "./files/04-recursive")
+}
+
+func TestEntryPoint(t *testing.T) {
+	RegisterTestingT(t)
+
+	target := getRegistry() + "/publish/simple"
+	Expect(spectrum("build", "-b", "curlimages/curl:latest",
+		"-t", target,
+		"--push-insecure="+getRegistryInsecure(),
+		"--clear-entrypoint",
+		"./files/01-simple:/app")).To(BeNil())
+
+	entrypoint := getImageEntrypoint(target, isRegistryInsecure())
+	assert.Nil(t, entrypoint)
 }

--- a/e2e/test_support.go
+++ b/e2e/test_support.go
@@ -44,6 +44,24 @@ func spectrum(args ...string) error {
 	return spectrum.Execute()
 }
 
+func getImageEntrypoint(image string, insecure bool) []string {
+	options := []crane.Option(nil)
+	if insecure {
+		options = append(options, crane.Insecure)
+	}
+
+	img, err := crane.Pull(image, options...)
+	if err != nil {
+		panic(err)
+	}
+
+	configFile, err := img.ConfigFile()
+	if err != nil {
+		panic(err)
+	}
+	return configFile.Config.Entrypoint
+}
+
 func getImageAnnotations(image string, insecure bool) map[string]string {
 	options := []crane.Option(nil)
 	if insecure {

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -54,6 +54,25 @@ func Build(options Options, dirs ...string) (string, error) {
 		return "", errors.Wrap(err, "could not append tar layers to base image")
 	}
 
+	if err != nil {
+		panic(err)
+	}
+
+	if options.ClearEntrypoint == true {
+		StepLogger.Println("Clearing entrypoint...")
+		// Change the entry point
+		confFile, err := newImage.ConfigFile()
+		if err != nil {
+			panic(err)
+		}
+		confFile.Config.Entrypoint = nil
+
+		newImage, err = mutate.Config(newImage, confFile.Config)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	StepLogger.Printf("Pushing image %s (insecure=%v)...", options.Target, options.PushInsecure)
 
 	if err := Push(newImage, options); err != nil {

--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -3,15 +3,16 @@ package builder
 import "io"
 
 type Options struct {
-	PullInsecure  bool
-	PushInsecure  bool
-	PullConfigDir string
-	PushConfigDir string
-	Base          string
-	Target        string
-	Annotations   map[string]string
-	Stdout        io.Writer
-	Stderr        io.Writer
-	Recursive     bool
-	Jobs          int
+	PullInsecure    bool
+	PushInsecure    bool
+	PullConfigDir   string
+	PushConfigDir   string
+	Base            string
+	Target          string
+	Annotations     map[string]string
+	Stdout          io.Writer
+	Stderr          io.Writer
+	Recursive       bool
+	Jobs            int
+	ClearEntrypoint bool
 }

--- a/pkg/cmd/spectrum.go
+++ b/pkg/cmd/spectrum.go
@@ -66,6 +66,7 @@ func Spectrum() *cobra.Command {
 			return nil
 		},
 	}
+
 	build.Flags().StringVarP(&options.Base, "base", "b", "", "Base container image to use")
 	build.Flags().StringVarP(&options.Target, "target", "t", "", "Target container image to use")
 	build.Flags().BoolVarP(&options.PullInsecure, "pull-insecure", "", false, "If the base image is hosted in an insecure registry")
@@ -75,6 +76,7 @@ func Spectrum() *cobra.Command {
 	build.Flags().StringSliceVarP(&options.annotationList, "annotations", "a", nil, "A list of annotations in the key=value format to add to the final image")
 	build.Flags().BoolVarP(&options.quiet, "quiet", "q", false, "Do not print logs to stdout and stderr")
 	build.Flags().BoolVarP(&options.Recursive, "recursive", "r", false, "Copy content from the source filesystem directory recursively")
+	build.Flags().BoolVar(&options.ClearEntrypoint, "clear-entrypoint", false, "Clear any entrypoint defined")
 	cmd.AddCommand(&build)
 
 	version := cobra.Command{


### PR DESCRIPTION
With this PR we enable the `--clear-entrypoint` option that will remove any entrypoint set on the source image.