### PR TITLE
feat: enable user override

### DIFF
--- a/e2e/core_test.go
+++ b/e2e/core_test.go
@@ -102,6 +102,23 @@ func TestEntryPoint(t *testing.T) {
 		"--clear-entrypoint",
 		"./files/01-simple:/app")).To(BeNil())
 
-	entrypoint := getImageEntrypoint(target, isRegistryInsecure())
+	entrypoint, err := getImageEntrypoint(target, isRegistryInsecure())
+	assert.Nil(t, err)
 	assert.Nil(t, entrypoint)
+}
+
+func TestUser(t *testing.T) {
+	RegisterTestingT(t)
+
+	target := getRegistry() + "/publish/simple"
+	Expect(spectrum("build", "-b", "adoptopenjdk/openjdk8:slim",
+		"-t", target,
+		"--push-insecure="+getRegistryInsecure(),
+		"--run-as",
+		"1000",
+		"./files/01-simple:/app")).To(BeNil())
+
+	user, err := getImageUser(target, isRegistryInsecure())
+	assert.Nil(t, err)
+	assert.Equal(t, "1000", user)
 }

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -53,7 +53,7 @@ func Build(options Options, dirs ...string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "could not append tar layers to base image")
 	}
-
+	confFile, err := newImage.ConfigFile()
 	if err != nil {
 		panic(err)
 	}
@@ -61,12 +61,17 @@ func Build(options Options, dirs ...string) (string, error) {
 	if options.ClearEntrypoint == true {
 		StepLogger.Println("Clearing entrypoint...")
 		// Change the entry point
-		confFile, err := newImage.ConfigFile()
+		confFile.Config.Entrypoint = nil
+		newImage, err = mutate.Config(newImage, confFile.Config)
 		if err != nil {
 			panic(err)
 		}
-		confFile.Config.Entrypoint = nil
+	}
 
+	if options.RunAs != "" {
+		StepLogger.Printf("Setting user as %s", options.RunAs)
+		// Change the configured USER
+		confFile.Config.User = options.RunAs
 		newImage, err = mutate.Config(newImage, confFile.Config)
 		if err != nil {
 			panic(err)

--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -15,4 +15,5 @@ type Options struct {
 	Recursive       bool
 	Jobs            int
 	ClearEntrypoint bool
+	RunAs           string
 }

--- a/pkg/cmd/spectrum.go
+++ b/pkg/cmd/spectrum.go
@@ -77,6 +77,7 @@ func Spectrum() *cobra.Command {
 	build.Flags().BoolVarP(&options.quiet, "quiet", "q", false, "Do not print logs to stdout and stderr")
 	build.Flags().BoolVarP(&options.Recursive, "recursive", "r", false, "Copy content from the source filesystem directory recursively")
 	build.Flags().BoolVar(&options.ClearEntrypoint, "clear-entrypoint", false, "Clear any entrypoint defined")
+	build.Flags().StringVar(&options.RunAs, "run-as", "", "User id/name used to run the container image")
 	cmd.AddCommand(&build)
 
 	version := cobra.Command{


### PR DESCRIPTION
May be useful when we want to run the image with a different user than the one provided by the base image