### PR TITLE
chore: update GoReleaser to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:
-        version: v0.184.0
-        args: release --rm-dist
+        version: v2.0.1
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod download
@@ -9,12 +10,13 @@ builds:
   ldflags: -X github.com/container-tools/spectrum/pkg/util.Version={{ .Tag }}
   id: spectrum
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+- name_template: >-
+    {{- .ProjectName }}_
+    {{- .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
- https://github.com/container-tools/spectrum/issues/95

While I looked into #95 , I found GoReleaser was very old.
To resolve #95 , I think we should upgrade GoReleaser to the latest version.
This pull request updates GoReleaser to the latest version and updates the configuration file.

## Test

I've confirmed I could build pre-built binary for darwin/arm64 and the naming style wasn't changed.

```console
$ goreleaser -v
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    2.0.1
GitCommit:     684c1805864e5f29acc204e34e1770eb74918d15
GitTreeState:  false
BuildDate:     2024-06-11T01:45:52Z
BuiltBy:       goreleaser
GoVersion:     go1.22.4
Compiler:      gc
ModuleSum:     h1:Wx2peRnvixEBRKxU6T0Gh+3wlire+Jv2IOW5eNPan3U=
Platform:      darwin/arm64
```

```console
$ goreleaser release --snapshot --clean
  • starting release...
  • loading                                          path=.goreleaser.yml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=aae3e613c9f03b346e5d58b23d0f2291c5c309cd branch=chore-update-goreleaser current_tag=v0.6.44 previous_tag=v0.6.43 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.6.44-next
  • running before hooks
    • running                                        hook=go mod download
  • checking distribution directory
    • cleaning dist
  • setting up metadata
  • storing release metadata
    • writing                                        file=dist/metadata.json
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/spectrum_windows_386/spectrum.exe
    • building                                       binary=dist/spectrum_darwin_amd64_v1/spectrum
    • building                                       binary=dist/spectrum_darwin_arm64/spectrum
    • building                                       binary=dist/spectrum_linux_386/spectrum
    • building                                       binary=dist/spectrum_linux_amd64_v1/spectrum
    • building                                       binary=dist/spectrum_linux_arm64/spectrum
    • building                                       binary=dist/spectrum_windows_amd64_v1/spectrum.exe
    • building                                       binary=dist/spectrum_windows_arm64/spectrum.exe
    • took: 1s
  • archives
    • creating                                       archive=dist/spectrum_v0.6.44-next_Windows_i386.tar.gz
    • creating                                       archive=dist/spectrum_v0.6.44-next_Windows_x86_64.tar.gz
    • creating                                       archive=dist/spectrum_v0.6.44-next_Windows_arm64.tar.gz
    • creating                                       archive=dist/spectrum_v0.6.44-next_Linux_arm64.tar.gz
    • creating                                       archive=dist/spectrum_v0.6.44-next_Linux_i386.tar.gz
    • creating                                       archive=dist/spectrum_v0.6.44-next_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/spectrum_v0.6.44-next_Linux_x86_64.tar.gz
    • creating                                       archive=dist/spectrum_v0.6.44-next_Darwin_arm64.tar.gz
    • took: 1s
  • calculating checksums
  • docker images
    • building docker image                          image=quay.io/container-tools/spectrum:v0.6.44
    • took: 1s
  • storing artifacts metadata
    • writing                                        file=dist/artifacts.json
  • release succeeded after 4s
  • thanks for using goreleaser!
```

```console
$ ls dist 
artifacts.json            spectrum_linux_amd64_v1                     spectrum_v0.6.44-next_Windows_arm64.tar.gz
checksums.txt             spectrum_linux_arm64                        spectrum_v0.6.44-next_Windows_i386.tar.gz
config.yaml               spectrum_v0.6.44-next_Darwin_arm64.tar.gz   spectrum_v0.6.44-next_Windows_x86_64.tar.gz
metadata.json             spectrum_v0.6.44-next_Darwin_x86_64.tar.gz  spectrum_windows_386
spectrum_darwin_amd64_v1  spectrum_v0.6.44-next_Linux_arm64.tar.gz    spectrum_windows_amd64_v1
spectrum_darwin_arm64     spectrum_v0.6.44-next_Linux_i386.tar.gz     spectrum_windows_arm64
spectrum_linux_386        spectrum_v0.6.44-next_Linux_x86_64.tar.gz
```